### PR TITLE
Update to Work on safari inside of Ionic 5

### DIFF
--- a/src/header-scroll-opacity.directive.ts
+++ b/src/header-scroll-opacity.directive.ts
@@ -113,7 +113,7 @@ export class IonHeaderScrollOpacityDirective implements OnInit, OnDestroy {
    * Extract the toolbar-background element from the toolbar shadow dom
    */
   get toolbarBackgroundEl() {
-    return this.toolbarEl.shadowRoot.children[0];
+    return this.toolbarEl.shadowRoot.querySelector('.toolbar-background');
   }
 
   changeOpacity() {


### PR DESCRIPTION
On Ionic 5 the first Child of the Shadow DOM inside toolbar is a style element and not the toolbar-background element. This is only on safari and not on Chrome.